### PR TITLE
Fix bower install due to .bowerrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 
 .DS_Store
 node_modules
-bower_components
+components

--- a/test/index.html
+++ b/test/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8">
         <title>Parallax Scrolling Plugin</title>
-        <link rel="stylesheet" href="../bower_components/normalize.css/normalize.css">
+        <link rel="stylesheet" href="../components/normalize.css/normalize.css">
         <link rel="stylesheet" href="test.css">
     </head>
     <body>
@@ -35,8 +35,8 @@
             </div>
         </div>
 
-        <script src="../bower_components/jquery/dist/jquery.js"></script>
-        <script src="../bower_components/raf.js/raf.js"></script>
+        <script src="../components/jquery/dist/jquery.js"></script>
+        <script src="../components/raf.js/raf.js"></script>
         <script src="../hongkong.js"></script>
     </body>
 </html>


### PR DESCRIPTION
This uses components folder instead of bower_components,
as specified in bowerrc.
